### PR TITLE
Remove-wrapper-button

### DIFF
--- a/blocks/src/details-wrapper/edit.js
+++ b/blocks/src/details-wrapper/edit.js
@@ -16,9 +16,7 @@ export default function Edit() {
 				<p class="wrapper-heading">Details wrapper</p>
 
 				<div {...innerBlocksProps}>
-					<div class="expand-wrap"><a class="expand-collapse" id="expand" href="#/">
-						{__('Expand All', 'details-wrapper')}
-					</a></div>
+
 					{ children }
 				</div>
 

--- a/blocks/src/details-wrapper/editor.scss
+++ b/blocks/src/details-wrapper/editor.scss
@@ -7,7 +7,6 @@
 .wp-block-ucsc-details-wrapper {
 	border: 1px solid #aaa;
 	border: 1px solid var(--wp--preset--color--light-gray);
-	border-radius: 4px;
 
 	.wrapper-heading {
 		color: #aaa;
@@ -15,5 +14,9 @@
 		font-size: 20px;
 		font-size: var(--wp--preset--font-size--medium);
 		margin-top: 0;
+	}
+
+	.wp-block-details {
+		border:none
 	}
 }

--- a/blocks/src/details-wrapper/style.scss
+++ b/blocks/src/details-wrapper/style.scss
@@ -32,12 +32,16 @@
 		.expand-collapse {
 			color: #32373c;
 			background-color: var(--wp--preset--color--lightest-gray);
-			padding: 0.5rem 0.5rem 0.5rem 0;
+			padding: 0.5rem 0.5rem 0.5rem 1.25rem;
 			text-decoration: none;
-			border-radius: 5px;
+			position:relative;
 
 		&::before {
-			font-family: dashicons, sans-serif;
+    	font-family: dashicons, sans-serif;
+    	position: absolute;
+    	top: 1.7em;
+    	left: 0.1em;
+    	margin-top: -1.3em;
 		}
 	}
 


### PR DESCRIPTION
Remove Expand/Collapse button from editor. Fix editor styles and front-end button styles.