### PR TITLE
fix: :bug: Remove ability to make a link in the summary of the details element

### DIFF
--- a/blocks/src/details/edit.js
+++ b/blocks/src/details/edit.js
@@ -64,6 +64,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 					<RichText
 						value={ summary }
 						onChange={ onChangeSummary }
+						allowedFormats={['core/bold', 'core/italic']} // Allow the content to be made bold or italic, but do not allow othe formatting options
 						placeholder={ __(
 							'Enter the summary text...',
 							'details'


### PR DESCRIPTION
Add 'allowedFormats' prop to `<RichText` element to only allow bold and italic formatting   Fixes #22